### PR TITLE
chore: fix postinstall command

### DIFF
--- a/packages/utils/eslint-utils/package.json
+++ b/packages/utils/eslint-utils/package.json
@@ -25,7 +25,6 @@
     "fmt": "yarn zz:cmd:prettier .",
     "gen-rules-type": "wireit",
     "gi": "wireit",
-    "postinstall": "wireit",
     "lint": "run-p lint:scripts lint:src",
     "lint:fix": "run-p lint:fix:scripts lint:fix:src",
     "lint:fix:scripts": "wireit",
@@ -185,9 +184,6 @@
       "output": [
         "./src/**/*.{mjs,mts,js,ts,jsx,tsx,d.mts,d.ts}"
       ]
-    },
-    "postinstall": {
-      "command": "yarn build"
     }
   }
 }

--- a/scripts/generate-configs-and-scripts/update-package-json.mjs
+++ b/scripts/generate-configs-and-scripts/update-package-json.mjs
@@ -889,11 +889,6 @@ const updatePackageJsonImpl = (
               mut_wireit[key] = property;
             }
           }
-
-          mut_scripts['postinstall'] = 'wireit';
-          mut_wireit['postinstall'] = {
-            command: 'yarn build',
-          };
         }
       }
     }


### PR DESCRIPTION
post install コマンドがバッティングして CI で確率的にエラーが発生してしまっていたのを修正。


```
Error: src/configs/common.mts(17,41): error TS2307: Cannot find module '../types/rules/eslint-import-rules.mjs' or its corresponding type declarations.
Error: src/configs/common.mts(21,8): error TS2307: Cannot find module '../types/rules/typescript-eslint-rules.mjs' or its corresponding type declarations.
Error: src/configs/cypress.mts(3,50): error TS2307: Cannot find module '../types/rules/typescript-eslint-rules.mjs' or its corresponding type declarations.
...
```